### PR TITLE
Remove not used handlers. Update documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ endif()
 
 
 add_library(
-    ${MAIN_TARGET} OBJECT
+    ${MAIN_TARGET} STATIC
     src/handlers.c
     src/init.c
     src/printf.c
@@ -48,7 +48,6 @@ target_include_directories(
     PUBLIC
         ${PROJECT_SOURCE_DIR}/inc)
 
-
 # Generate linker script
 add_custom_command(
     OUTPUT ${LINKER_SCRIPT} PRE_BUILD
@@ -73,7 +72,9 @@ target_link_libraries(
 
 target_link_options(
     hello PRIVATE
-    "-T${LINKER_SCRIPT}" -nostartfiles)
+    "-T${LINKER_SCRIPT}" -nostartfiles
+    -Wl,--whole-archive $<TARGET_FILE_NAME:${MAIN_TARGET}> -Wl,--no-whole-archive)
+
 target_postbuild_executable(hello ${CMAKE_INSTALL_BINDIR})
 
 install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,6 @@ if (CMAKE_BUILD_TYPE MATCHES "Debug")
     string(APPEND CMAKE_C_FLAGS " -O0")
 endif()
 
-
 add_library(
     ${MAIN_TARGET} STATIC
     src/handlers.c

--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ cmake --build --preset an386
 
 Libraries will be compiled and placed in the ``build/pack`` directory.
 
+## Linking with applications
+
+For some of the symbols, the runtime defines weak and strong symbols. It is hence important to use ``--whole-archive`` linker flag when linking the .a file.
+
+Normally, the linker only extracts object files from the library if they provide undefined symbols required by the application. While linking, if the application gets a weak symbol it won't try to resolve strong one. Weak symbols do not create unresolved references, so if any symbol is already defined (even as a weak symbol), the linker does not search ``.a`` for another definition. It is called lazy extraction.
+
+Use of the ``--whole-archive`` linker flag when linking the ``.a`` forces the linker to extract all the symbols, preventing the lazy extraction behavior.
 
 ## Test program
 

--- a/app/hello.c
+++ b/app/hello.c
@@ -21,7 +21,6 @@ int main(void) {
     platform_init(PLATFORM_CLOCK_MAX);
     platform_sync();
     size_t i = 0;
-    struct platform_attr_t a;
 
     uint64_t t = platform_cpu_cyclecount();
     i++;

--- a/src/startup.S
+++ b/src/startup.S
@@ -142,27 +142,6 @@ system_startup:
  * will be weak symbol and just dead loops. They can be
  * overwritten by other handlers
  */
-    .macro    def_default_handler    handler_name
-    .align 1
-    .thumb_func
-    .weak    \handler_name
-    .type    \handler_name, %function
-\handler_name :
-    b    .
-    .size    \handler_name, . - \handler_name
-    .endm
-
-    def_default_handler    NMI_Handler
-    def_default_handler    HardFault_Handler
-    def_default_handler    MemManage_Handler
-    def_default_handler    BusFault_Handler
-    def_default_handler    UsageFault_Handler
-    def_default_handler    SVC_Handler
-    def_default_handler    DebugMon_Handler
-    def_default_handler    PendSV_Handler
-    def_default_handler    SysTick_Handler
-    def_default_handler    Default_Handler
-
     .macro    def_irq_default_handler    handler_name
     .weak     \handler_name
     .set      \handler_name, Default_Handler


### PR DESCRIPTION
* Removes weak symbols for handlers from startup.s

* Prevent lazy extraction

For some of the symbols, the runtime defines weak and strong symbols. It is hence important to use ``--whole-archive`` linker flag when linking the ``.a`` file.

By default, the linker only extracts object files from the library if they provide undefined symbols required by the application. While linking, if the application gets a weak symbol it won't try to resolve strong one. Weak symbols do not create unresolved references, so if any symbol is already defined (even as a weak symbol), the linker does not search ``.a`` for another definition. It is called lazy extraction.

Use of the ``--whole-archive`` linker flag when linking the ``.a`` forces the linker to extract all the symbols, preventing the lazy extraction behavior.